### PR TITLE
Update database name connection variable to use environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,6 @@ host = "'your database endpoint'"
 
 * Now you may use the scripts available in the repository, these environment variables will be referenced later using the syntax Sys.getenv()
 
-### Allowing access to AWS instance
-
-* Connect to the AWS website and click on the RDS section
-
-* Click on the database labeled "clinicaltrialsdatabase"
-
-* Under the "Connectivity & security" tab, find "Security" and click on the blue link directly under "VPC security groups"
-
-* Click on the "inbound" tab and click edit
-
-* Click "Add Rule" and create a new Custom TCP Rule with port range 5432 and for the source drop-down menu click "My IP", then click save
-
-* If this is done correctly, your computer will now be able to pass through security and connect to the database
-
 ### Connecting to the database
 
 * First-time startup enter the command (this command will only ever need to be entered one time) `install.packages("RPostgreSQL")`
@@ -50,7 +36,7 @@ host = "'your database endpoint'"
 * Connect to database with user environment variables
 
 ```
-con <- dbConnect(drv,    dbname="aact",    host=Sys.getenv("host"),    port=5432,    user=Sys.getenv("userid"),    password=Sys.getenv("userpass"))
+con <- dbConnect(drv,    dbname=Sys.getenv("dbname"),    host=Sys.getenv("host"),    port=5432,    user=Sys.getenv("userid"),    password=Sys.getenv("userpass"))
 ```
 
 * Make the database schema public for easier query syntax `dbExecute(con, "SET search_path TO ctgov,public")

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ To access the clinical trials database, you will be prompted with a username and
 * Inside the file write your username, password, and host environment variables with your database login information:
 
 ``` 
+dbname = "aact_back"
 userid = "'your database account username'"
 userpass = "'your database account password'"
 host = "'your database endpoint'"

--- a/R_Scripts/gender_trials.R
+++ b/R_Scripts/gender_trials.R
@@ -21,7 +21,7 @@ tryCatch({
 # Connect to AACT database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact",
+                 dbname=Sys.getenv("dbname"),
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),

--- a/R_Scripts/pd_enrollment_numbers.R
+++ b/R_Scripts/pd_enrollment_numbers.R
@@ -21,7 +21,7 @@ tryCatch({
 # Connect to the database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact",
+                 dbname=Sys.getenv("dbname"),
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),

--- a/R_Scripts/stop_reason_vs_trial_condition_type_proportion.R
+++ b/R_Scripts/stop_reason_vs_trial_condition_type_proportion.R
@@ -21,7 +21,7 @@ tryCatch({
 # Connect to AACT database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact_back",
+                 dbname=Sys.getenv("dbname"),
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),
@@ -35,4 +35,7 @@ dbExecute(con, "SET search_path TO ctgov,public")
 stop <- dbGetQuery(con, "select why_stopped_table.nct_id, why_stopped_table.stop_reason, condition_type.condition_category FROM why_stopped_table JOIN condition_type ON why_stopped_table.nct_id = condition_type.nct_id WHERE why_stopped_table.stop_reason != 'Other'")
 
 # Plot a proportional analysis of trial stop reasons vs trial conditions
-ggplot(df, aes(x = stop.stop_reason, y = ..prop.., group = stop.condition_category)) + geom_bar(aes(fill = stop.condition_category), position = "dodge2") + labs(title="Proportional Analysis of Trial Stop Reason vs Trial Condition Type") + xlab("Stop Reason") + ylab("Proportion (%)") + scale_fill_discrete(name = "Condition Type")
+#ggplot(df, aes(x = stop.stop_reason, y = ..prop.., group = stop.condition_category)) + geom_bar(aes(fill = stop.condition_category), position = "dodge2") + labs(title="Proportional Analysis of Trial Stop Reason vs Trial Condition Type") + xlab("Stop Reason") + ylab("Proportion (%)") + scale_fill_discrete(name = "Condition Type")
+#ggplot(df, aes(x = stop.stop_reason, y = ..prop.., group = stop.condition_category)) + geom_bar(aes(fill = stop.condition_category), position = "dodge2") + labs(title="Proportional Analysis of Trial Stop Reason vs Trial Condition Type") + xlab("Stop Reason") + ylab("Proportion (%)") + scale_fill_discrete(name = "Condition Type") + coord_flip()
+ggplot(df, aes(x = stop.stop_reason, y = ..prop.., group = stop.condition_category)) + geom_bar(aes(fill = stop.condition_category), position = "dodge2") + labs(title="Proportional Analysis of Trial Stop Reason vs Trial Condition Type") + xlab("Stop Reason") + ylab("Proportion (%)") + scale_fill_discrete(name = "Condition Type") + scale_x_discrete(limits = c("Enrollment","Accrual","Sponsor or PI decision","Lack of funding","Ineffective or futile","Safety","Business Decision","Administrative decision","Feasibility reasons","Logistic Reasons","Toxicity")) + coord_flip() + scale_y_continuous(labels=scales::percent)
+#ggplot(df, aes(x = stop.stop_reason, y = ..prop.., group = stop.condition_category)) + geom_bar(aes(fill = stop.condition_category), position = "dodge2") + labs(title="Proportional Analysis of Trial Stop Reason vs Trial Condition Type") + xlab("Stop Reason") + ylab("Proportion (%)") + scale_fill_discrete(name = "Condition Type") + scale_x_discrete(limits = c("Enrollment","Accrual","Sponsor or PI decision","Lack of funding","Ineffective or futile","Safety","Business Decision","Administrative decision","Feasibility reasons","Logistic Reasons","Toxicity")) + coord_flip() + scale_y_continuous(labels=scales::percent) + facet_wrap(~ stop.condition_category, ncol=4)

--- a/R_Scripts/study_type_pd.R
+++ b/R_Scripts/study_type_pd.R
@@ -21,7 +21,7 @@ tryCatch({
 # Connect to AACT database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact_back",
+                 dbname=Sys.getenv("dbname"),
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),

--- a/R_Scripts/study_type_pd.R
+++ b/R_Scripts/study_type_pd.R
@@ -21,7 +21,7 @@ tryCatch({
 # Connect to AACT database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact",
+                 dbname="aact_back",
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),
@@ -45,3 +45,4 @@ plot <- ggplot(data=x, aes(x=study_type, y=count)) + geom_bar(stat="identity") +
   theme(plot.title = element_text(hjust = 0.5),
         plot.caption=element_text(hjust=0.5, vjust=0.5))
 plot + scale_y_continuous(labels = comma)
+

--- a/R_Scripts/total_trials_enrollment_count.R
+++ b/R_Scripts/total_trials_enrollment_count.R
@@ -15,7 +15,7 @@ tryCatch({
 # Connect to database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact",
+                 dbname=Sys.getenv("dbname"),
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),

--- a/R_Scripts/total_trials_starting_month.R
+++ b/R_Scripts/total_trials_starting_month.R
@@ -21,7 +21,7 @@ tryCatch({
 # Connect to database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact",
+                 dbname=Sys.getenv("dbname"),
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),

--- a/R_Scripts/trial_intervention_type_plot.R
+++ b/R_Scripts/trial_intervention_type_plot.R
@@ -21,7 +21,7 @@ tryCatch({
 # Connect to AACT database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact_back",
+                 dbname=Sys.getenv("dbname"),
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),

--- a/R_Scripts/trial_intervention_type_plot.R
+++ b/R_Scripts/trial_intervention_type_plot.R
@@ -21,7 +21,7 @@ tryCatch({
 # Connect to AACT database
 drv <- dbDriver('PostgreSQL')
 con <- dbConnect(drv,
-                 dbname="aact",
+                 dbname="aact_back",
                  host=Sys.getenv("host"),
                  port=5432,
                  user=Sys.getenv("userid"),
@@ -43,3 +43,4 @@ plot <- ggplot(data=x, aes(x=intervention_type, y=count)) + geom_bar(stat="ident
 
 # Show graph without scientific notation on y axis
 plot + scale_y_continuous(labels = comma)
+


### PR DESCRIPTION
Our older scripts used an outdated database name, changing the documentation and scripts to use a saved environment variable will prove to make configuration easier in the future.